### PR TITLE
Move all fail and semigroups into conditional dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -55,7 +55,6 @@ dependencies:
   - cryptohash >=0.11.6
   - deepseq >=1.3.0.2
   - directory >= 1.2
-  - fail >= 4.9
   - filepath >= 1.3
   - ghc-prim >=0.3.1.0
   - hashable >=1.2.3.1
@@ -66,7 +65,6 @@ dependencies:
   - mono-traversable >=0.7.0
   - resourcet >=1.1.3.3
   - safe >=0.3.8
-  - semigroups >=0.8
   - smallcheck >=1.1.1
   - syb >=0.4.4
   - template-haskell >=2.9.0.0
@@ -92,6 +90,10 @@ when:
     else:
       dependencies: integer-gmp >= 0.5.1.0
       cpp-options: -DINTEGER_GMP
+  - condition: impl(ghc < 8.0)
+    dependencies:
+      - fail >=4.9
+      - semigroups >=0.8
 library:
   source-dirs: src
   other-modules:

--- a/store-streaming/package.yaml
+++ b/store-streaming/package.yaml
@@ -18,7 +18,6 @@ dependencies:
   - base >=4.7 && <5
   - bytestring >=0.10.4.0
   - conduit >=1.2.3.1
-  - fail >=4.9
   - free >=4.11
   - resourcet >=1.1.3.3
   - store >=0.4.3.4
@@ -26,6 +25,10 @@ dependencies:
   - streaming-commons >=0.1.10.0
   - text >=1.2.0.4
   - transformers >=0.3.0.0
+
+when:
+  - condition: impl(ghc < 8.0)
+    dependencies: fail >=4.9
 
 library:
   source-dirs: src


### PR DESCRIPTION
They are not needed on new GHC releases.