### PR TITLE
test/Data/StoreSpec.hs: tweak for network-3.1

### DIFF
--- a/test/Data/StoreSpec.hs
+++ b/test/Data/StoreSpec.hs
@@ -102,9 +102,11 @@ $(mkManyHasTypeHash [ [t| Int32 |] ])
 -- Serial instances for (Num a, Bounded a) types. Only really
 -- appropriate for the use here.
 
+#if !MIN_VERSION_network(3,1,0)
 instance Bounded PortNumber where
   minBound = 0
   maxBound = 65535
+#endif
 
 $(do let ns = [ ''PortNumber
 


### PR DESCRIPTION
On networt-3.1 testsuite fails build on duplicate instance definition
for Bounded PortNumber:

```
test/Data/StoreSpec.hs:105:10: error:
    Duplicate instance declarations:
      instance Bounded PortNumber
        -- Defined at test/Data/StoreSpec.hs:105:10
      instance Bounded PortNumber
        -- Defined in ‘network-3.1.2.1:Network.Socket.Types’
```

The change uses network's instance if available.