### PR TITLE
Use cryptohash-sha1 instead of the deprecated cryptohash

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211111
+# version: 0.16.5
 #
-# REGENDATA ("0.13.20211111",["github","cabal.project"])
+# REGENDATA ("0.16.5",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,7 +23,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -32,15 +32,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.4.5
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            compilerVersion: 9.2.8
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
@@ -57,34 +67,27 @@ jobs:
             compilerVersion: 8.4.4
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y "$HCNAME"
-          mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
-          chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -96,11 +99,20 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HCDIR/bin/$HCKIND
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -150,14 +162,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -189,12 +201,12 @@ jobs:
           echo "packages: ${PKGDIR_store}" >> cabal.project
           echo "packages: ${PKGDIR_store_core}" >> cabal.project
           echo "packages: ${PKGDIR_store_streaming}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package store" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package store-core" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package store-streaming" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package store" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "package store-core" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "package store-streaming" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(store|store-core|store-streaming)$/; }' >> cabal.project.local
@@ -204,8 +216,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -225,8 +237,14 @@ jobs:
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: haskell/actions/hlint-setup@v2
       name: Set up HLint
       with:
-        version: "3.4"
+        version: "3.5"
 
     - uses: haskell/actions/hlint-run@v2
       name: hlint

--- a/package.yaml
+++ b/package.yaml
@@ -10,14 +10,13 @@ extra-source-files:
   - ChangeLog.md
   - README.md
 tested-with:
-  - GHC==9.0.1
-  - GHC==8.10.4
+  - GHC==9.4.5
+  - GHC==9.2.8
+  - GHC==9.0.2
+  - GHC==8.10.7
   - GHC==8.8.4
   - GHC==8.6.5
   - GHC==8.4.4
-  - GHC==8.2.2
-  - GHC==8.0.2
-  - GHC==7.10.3
 
 flags:
   comparison-bench:

--- a/package.yaml
+++ b/package.yaml
@@ -59,7 +59,7 @@ dependencies:
   - base64-bytestring >= 0.1.1
   - bytestring >=0.10.4.0
   - containers >=0.5.5.1
-  - cryptohash >=0.11.6
+  - cryptohash-sha1 >=0.11.6
   - deepseq >=1.3.0.2
   - directory >= 1.2
   - filepath >= 1.3

--- a/store-core/package.yaml
+++ b/store-core/package.yaml
@@ -9,14 +9,13 @@ category: Serialization, Data
 extra-source-files:
   - ChangeLog.md
 tested-with:
-  - GHC==9.0.1
-  - GHC==8.10.4
+  - GHC==9.4.5
+  - GHC==9.2.8
+  - GHC==9.0.2
+  - GHC==8.10.7
   - GHC==8.8.4
   - GHC==8.6.5
   - GHC==8.4.4
-  - GHC==8.2.2
-  - GHC==8.0.2
-  - GHC==7.10.3
 
 flags:
   force-alignment:

--- a/store-core/store-core.cabal
+++ b/store-core/store-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -16,14 +16,13 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC==9.0.1
-  , GHC==8.10.4
+    GHC==9.4.5
+  , GHC==9.2.8
+  , GHC==9.0.2
+  , GHC==8.10.7
   , GHC==8.8.4
   , GHC==8.6.5
   , GHC==8.4.4
-  , GHC==8.2.2
-  , GHC==8.0.2
-  , GHC==7.10.3
 extra-source-files:
     ChangeLog.md
 
@@ -50,9 +49,9 @@ library
     , primitive >=0.6 && <1.0
     , text >=1.2.0.4 && <1.3 || >=2.0 && <2.1
     , transformers >=0.3.0.0 && <1.0
+  default-language: Haskell2010
   if flag(force-alignment) || arch(PPC) || arch(PPC64) || arch(Mips) || arch(Sparc) || arch(Arm)
     cpp-options: -DALIGNED_MEMORY
   if impl(ghc < 8.0)
     build-depends:
         fail >=4.9
-  default-language: Haskell2010

--- a/store-streaming/package.yaml
+++ b/store-streaming/package.yaml
@@ -11,14 +11,13 @@ category: Serialization, Data
 extra-source-files:
   - ChangeLog.md
 tested-with:
-  - GHC==9.0.1
-  - GHC==8.10.4
+  - GHC==9.4.5
+  - GHC==9.2.8
+  - GHC==9.0.2
+  - GHC==8.10.7
   - GHC==8.8.4
   - GHC==8.6.5
   - GHC==8.4.4
-  - GHC==8.2.2
-  - GHC==8.0.2
-  - GHC==7.10.3
 
 ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -O2
 

--- a/store-streaming/store-streaming.cabal
+++ b/store-streaming/store-streaming.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -16,14 +16,13 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC==9.0.1
-  , GHC==8.10.4
+    GHC==9.4.5
+  , GHC==9.2.8
+  , GHC==9.0.2
+  , GHC==8.10.7
   , GHC==8.8.4
   , GHC==8.6.5
   , GHC==8.4.4
-  , GHC==8.2.2
-  , GHC==8.0.2
-  , GHC==7.10.3
 extra-source-files:
     ChangeLog.md
 
@@ -52,10 +51,10 @@ library
     , streaming-commons >=0.1.10.0
     , text >=1.2.0.4
     , transformers >=0.3.0.0
+  default-language: Haskell2010
   if impl(ghc < 8.0)
     build-depends:
         fail >=4.9
-  default-language: Haskell2010
 
 test-suite store-test
   type: exitcode-stdio-1.0
@@ -85,7 +84,7 @@ test-suite store-test
     , text >=1.2.0.4
     , transformers >=0.3.0.0
     , void
+  default-language: Haskell2010
   if impl(ghc < 8.0)
     build-depends:
         fail >=4.9
-  default-language: Haskell2010

--- a/store.cabal
+++ b/store.cabal
@@ -16,14 +16,13 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC==9.0.1
-  , GHC==8.10.4
+    GHC==9.4.5
+  , GHC==9.2.8
+  , GHC==9.0.2
+  , GHC==8.10.7
   , GHC==8.8.4
   , GHC==8.6.5
   , GHC==8.4.4
-  , GHC==8.2.2
-  , GHC==8.0.2
-  , GHC==7.10.3
 extra-source-files:
     ChangeLog.md
     README.md

--- a/store.cabal
+++ b/store.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -70,7 +70,7 @@ library
     , bytestring >=0.10.4.0
     , containers >=0.5.5.1
     , contravariant >=1.3
-    , cryptohash >=0.11.6
+    , cryptohash-sha1 >=0.11.6
     , deepseq >=1.3.0.2
     , directory >=1.2
     , filepath >=1.3
@@ -102,6 +102,7 @@ library
     , unordered-containers >=0.2.5.1
     , vector >=0.10.12.3
     , void >=0.5.11
+  default-language: Haskell2010
   if flag(integer-simple)
     build-depends:
         integer-simple >=0.1.1.1
@@ -113,7 +114,6 @@ library
     build-depends:
         fail >=4.9
       , semigroups >=0.8
-  default-language: Haskell2010
 
 test-suite store-test
   type: exitcode-stdio-1.0
@@ -139,7 +139,7 @@ test-suite store-test
     , clock >=0.3
     , containers >=0.5.5.1
     , contravariant >=1.3
-    , cryptohash >=0.11.6
+    , cryptohash-sha1 >=0.11.6
     , deepseq >=1.3.0.2
     , directory >=1.2
     , filepath >=1.3
@@ -172,6 +172,7 @@ test-suite store-test
     , unordered-containers >=0.2.5.1
     , vector >=0.10.12.3
     , void >=0.5.11
+  default-language: Haskell2010
   if flag(integer-simple)
     build-depends:
         integer-simple >=0.1.1.1
@@ -183,7 +184,6 @@ test-suite store-test
     build-depends:
         fail >=4.9
       , semigroups >=0.8
-  default-language: Haskell2010
 
 benchmark store-bench
   type: exitcode-stdio-1.0
@@ -204,7 +204,7 @@ benchmark store-bench
     , containers >=0.5.5.1
     , contravariant >=1.3
     , criterion
-    , cryptohash >=0.11.6
+    , cryptohash-sha1 >=0.11.6
     , deepseq >=1.3.0.2
     , directory >=1.2
     , filepath >=1.3
@@ -237,6 +237,7 @@ benchmark store-bench
     , unordered-containers >=0.2.5.1
     , vector >=0.10.12.3
     , void >=0.5.11
+  default-language: Haskell2010
   if flag(integer-simple)
     build-depends:
         integer-simple >=0.1.1.1
@@ -257,7 +258,6 @@ benchmark store-bench
       , vector-binary-instances
   if flag(small-bench)
     cpp-options: -DSMALL_BENCH
-  default-language: Haskell2010
 
 benchmark store-weigh
   type: exitcode-stdio-1.0
@@ -278,7 +278,7 @@ benchmark store-weigh
     , containers >=0.5.5.1
     , contravariant >=1.3
     , criterion
-    , cryptohash >=0.11.6
+    , cryptohash-sha1 >=0.11.6
     , deepseq >=1.3.0.2
     , directory >=1.2
     , filepath >=1.3
@@ -313,6 +313,7 @@ benchmark store-weigh
     , vector-binary-instances
     , void >=0.5.11
     , weigh
+  default-language: Haskell2010
   if flag(integer-simple)
     build-depends:
         integer-simple >=0.1.1.1
@@ -324,4 +325,3 @@ benchmark store-weigh
     build-depends:
         fail >=4.9
       , semigroups >=0.8
-  default-language: Haskell2010

--- a/test/Data/StoreSpec.hs
+++ b/test/Data/StoreSpec.hs
@@ -86,6 +86,7 @@ import qualified Data.Time.Format.ISO8601 as Time
 #endif
 #if MIN_VERSION_time(1,11,0)
 import qualified Data.Time.Calendar.Quarter as Time
+import qualified Data.Time.Calendar.WeekDate as Time
 #endif
 
 #if !MIN_VERSION_smallcheck(1,2,0)


### PR DESCRIPTION
also drops several transitive dependencies like cryptonite, memory and basement

Closes #52