### PR TITLE
Fix tests for time 1.11

### DIFF
--- a/test/Data/StoreSpec.hs
+++ b/test/Data/StoreSpec.hs
@@ -86,6 +86,7 @@ import qualified Data.Time.Format.ISO8601 as Time
 #endif
 #if MIN_VERSION_time(1,11,0)
 import qualified Data.Time.Calendar.Quarter as Time
+import qualified Data.Time.Calendar.WeekDate as Time
 #endif
 
 #if !MIN_VERSION_smallcheck(1,2,0)


### PR DESCRIPTION
This PR fixes a compilation error when building the tests using GHC 9.2.8 and time 1.11.1.1:

```
test/Data/StoreSpec.hs:357:24: error:
    • Not in scope: type constructor or class ‘Time.FirstWeekType’
      Neither ‘Data.Time’, ‘Data.Time.Calendar.Quarter’,
              ‘Data.Time.Clock.System’,
              ‘Data.Time.Clock.TAI’ nor ‘Data.Time.Format.ISO8601’ exports ‘FirstWeekType’.
    • In the Template Haskell quotation [t| Time.FirstWeekType |]
      In the untyped splice:
        $(do insts <- getAllInstanceTypes1 ''Store
             omitTys0 <- sequence
                           $ [[t| CUIntPtr |], [t| CIntPtr |], [t| IntPtr |], ....]
             omitTys <- (omitTys0 ++)
                          <$> mapM (\ ty -> [t| PV.Vector $(pure ty) |]) omitTys0
             let f ty
                   = isMonoType ty && ty `notElem` omitTys
                       && null (listify isThName ty)
                 filtered = filter f insts
                 isThName n = nameModule n == Just "Language.Haskell.TH.Syntax"
             smallcheckManyStore verbose 2 $ map return filtered)
    |
357 |                  , [t| Time.FirstWeekType |]
    |                        ^^^^^^^^^^^^^^^^^^
```

This issue is similar to #162, but only affects the tests. The fix is analogous to #164.

cc @mgsloan 

Please make a new release after merging as this fix is needed for Arch to move to GHC 9.2